### PR TITLE
Fix cURL redirect URL, XSS in config UI, config caching, and byte size check (v0.3)

### DIFF
--- a/configure.phtml
+++ b/configure.phtml
@@ -12,7 +12,7 @@ declare(strict_types=1);
 		foreach ($this->getCategories() as $c) {
 		?>
 
-			<h3><?php echo $c->name()?></h3>
+			<h3><?php echo htmlspecialchars($c->name(), ENT_QUOTES, 'UTF-8') ?></h3>
 			<table>
 			<tr>
 				<td class="rotate"><div><span>Readability</span></div></td>
@@ -25,7 +25,7 @@ declare(strict_types=1);
 					name="cat_<?php echo $c->id() ?>"
 					value="1" <?php echo $this->getConfigCategories($c->id()) ? 'checked="checked"' : ''; ?> >
 				</td>
-				<td class="boldtd" >Whole Category: <?php echo $c->name()?></td>
+				<td class="boldtd" >Whole Category: <?php echo htmlspecialchars($c->name(), ENT_QUOTES, 'UTF-8') ?></td>
 			</tr>
 
 				<?php
@@ -44,7 +44,7 @@ declare(strict_types=1);
 					>
 
 					</td>
-					<td><?php echo $f->name() ?></td>
+					<td><?php echo htmlspecialchars($f->name(), ENT_QUOTES, 'UTF-8') ?></td>
 					</tr>
 
 				<?php

--- a/extension.php
+++ b/extension.php
@@ -14,6 +14,7 @@ class Af_ReadabilityExtension extends Minz_Extension
 	private array $configFeeds = [];
 	/** @var array<int,bool> */
 	private array $configCategories = [];
+	private bool $configLoaded = false;
 
 	public function init()
 	{
@@ -65,8 +66,11 @@ class Af_ReadabilityExtension extends Minz_Extension
 	*/
 	private function loadConfigValues(): void
 	{
+		if ($this->configLoaded) {
+			return;
+		}
 		if (!class_exists('FreshRSS_Context', false)) {
-			echo "Failed data";
+			Minz_Log::warning('af-readability: FreshRSS_Context class not found');
 			return;
 		}
 		try {
@@ -79,6 +83,7 @@ class Af_ReadabilityExtension extends Minz_Extension
 
 		$this->configFeeds = $this->readConfigValue($userConf, 'ext_af_readability_feeds');
 		$this->configCategories = $this->readConfigValue($userConf, 'ext_af_readability_categories');
+		$this->configLoaded = true;
 	}
 
 	/** @return array<int,bool> */
@@ -169,17 +174,16 @@ class Af_ReadabilityExtension extends Minz_Extension
 			'Accept: text/*',
 			'Content-Type: text/html'
 		]);
+		curl_setopt($ch, CURLOPT_ACCEPT_ENCODING, '');
+		curl_setopt($ch, CURLOPT_TIMEOUT, 15);
 		$response = curl_exec($ch);
 		if (curl_errno($ch)) {
 			return false;
 		}
-		$redirectUrl = curl_getinfo($ch, CURLINFO_REDIRECT_URL);
-		if (!empty($redirectUrl)) {
-			$url = $redirectUrl;
-		}
+		$url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL) ?: $url;
 		curl_close($ch);
 
-		if (!is_string($response) || mb_strlen($response) > 1024 * 500) {
+		if (!is_string($response) || strlen($response) > 1024 * 500) {
 			return false;
 		}
 

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Af_Readability",
 	"author": "niehztog",
 	"description": "Try to inline article content using Readability",
-	"version": "0.2",
+	"version": "0.3",
 	"entrypoint": "Af_Readability",
 	"type": "user"
 }


### PR DESCRIPTION
## Summary

- **Bug fix:** Use `CURLINFO_EFFECTIVE_URL` instead of `CURLINFO_REDIRECT_URL`
- **Security:** Escape feed/category names with `htmlspecialchars()` in `configure.phtml`
- **Performance:** Cache loaded config with a `$configLoaded` flag
- **Bug fix:** Replace `mb_strlen` with `strlen` for the 500KB byte size cap
- **Code quality:** Replace bare `echo` with `Minz_Log::warning()`

## Test plan

- [ ] Verify articles still extract correctly for enabled feeds
- [ ] Verify feeds with redirect URLs produce correctly resolved relative URLs
- [ ] Confirm configuration page renders correctly
- [ ] Confirm no raw text is output to the HTTP response on misconfiguration